### PR TITLE
ENH: added tracking on non-logged in users and timestamp for video

### DIFF
--- a/crud/crud.py
+++ b/crud/crud.py
@@ -315,6 +315,12 @@ def increase_view(db: Session, video_int: int, active_user: schemas.User):
         db.add(video_view)
         db.commit()
         db.refresh(video_view)
+    # record unknown user views also
+    else:
+        video_view = models.VideoViews(video_id=video.video_id, user_id=None)
+        db.add(video_view)
+        db.commit()
+        db.refresh(video_view)
     # incease by 1
     video.views += 1
     # commit to database

--- a/templates/index.html
+++ b/templates/index.html
@@ -27,6 +27,7 @@
           <h6 class="videoName w-100">{{ video.video_name }}</h6>
           <p class="videoUsername">{{ video.video_username }}</p>
           <strong class="viewCount">{{ video.views }} views</strong>
+          <h6 class="timestampVideo">Uploaded {{ video.ts_upload }}</h6>
     </div>
     {% endfor %}
   </div>


### PR DESCRIPTION
- [x] #99 
- [x] tests passed
- [x] Ensure all linting tests/pre-commit pass, see [here](https://myview.readthedocs.io/en/latest/contributing_guide_code.html) for how to run them.
- [x] added tracking for views on user not logged in, added timestamp for uploaded in homepage